### PR TITLE
match the fosdem audio board as an audio output

### DIFF
--- a/templates/obs-station-amd/dev-mapping.nix
+++ b/templates/obs-station-amd/dev-mapping.nix
@@ -8,15 +8,19 @@
   };
 
   mixos.devMap = {
-    videoCapture = {
+    videoCapture.by-path = {
       "pci-0000:05:00.0-usbv3-0:1:1.0" = { name = "video-lecturer"; };
       "pci-0000:05:00.0-usbv3-0:2:1.0" = { name = "video-overview"; };
       "pci-0000:05:00.0-usbv3-0:3:1.0" = { name = "video-closeup"; };
     };
 
-    audio = {
+    audio.by-path = {
       "pci-0000:05:00.0-usb-0:1:1.2" = { name = "capture-lecturer"; };
       "pci-0000:05:00.0-usb-0:2:1.2" = { name = "capture-overview"; };
+    };
+
+    audio.by-name = {
+      "~alsa_card.usb-FOSDEM_Audio_Board_" = { name = "out-streamcam"; };
     };
   };
 }

--- a/templates/obs-station-nvidia/dev-mapping.nix
+++ b/templates/obs-station-nvidia/dev-mapping.nix
@@ -8,13 +8,13 @@
   };
 
   mixos.devMap = {
-    videoCapture = {
+    videoCapture.by-path = {
       "pci-0000:03:00.0-usbv3-0:1:1.0" = { name = "video-lecturer"; };
       "pci-0000:03:00.0-usbv3-0:2:1.0" = { name = "video-overview"; };
       "pci-0000:03:00.0-usbv3-0:3:1.0" = { name = "video-closeup"; };
     };
 
-    audio = {
+    audio.by-path = {
       "pci-0000:03:00.0-usb-0:1:1.2" = { name = "capture-lecturer"; };
       "pci-0000:03:00.0-usb-0:2:1.2" = { name = "capture-overview"; };
     };


### PR DESCRIPTION
- Modify the device mapper to support matching audio devices by name instead of path (we don't want to restrict which port the audio board is plugged into, so we match it by name; however, for the v4l audio we distinguish the otherwise-identical capture cards by port, so we match them by path).
- Use said feature to configure the fosdem audio board as `streamcam-out`, which will then be used to output video and lecturer laptop audio.