### PR TITLE
fuck nixos-generators

### DIFF
--- a/common/platforms/x86_64-virtio-qemu-img.nix
+++ b/common/platforms/x86_64-virtio-qemu-img.nix
@@ -1,5 +1,33 @@
-{ ... }: {
-  boot.initrd.availableKernelModules =
-    [ "virtio_pci" "virtio_blk" "virtio_scsi" "virtio_console" "virtio_net" ];
-  # do not override image settings, use whatever nixos-generators provides
+{ config, lib, pkgs, modulesPath, ... }: {
+  # for virtio kernel drivers
+  imports = [ "${toString modulesPath}/profiles/qemu-guest.nix" ];
+
+  config = {
+    fileSystems."/" = {
+      device = "/dev/disk/by-label/nixos";
+      autoResize = true;
+      fsType = "ext4";
+    };
+
+    fileSystems."/boot" = {
+      device = "/dev/disk/by-label/ESP";
+      fsType = "vfat";
+    };
+
+    boot.growPartition = true;
+    boot.kernelParams = [ "console=ttyS0,115200" ];
+    boot.loader.grub.device = "nodev";
+
+    boot.loader.grub.efiSupport = true;
+    boot.loader.grub.efiInstallAsRemovable = true;
+    boot.loader.timeout = 0;
+
+    system.build.qcow-efi =
+      import "${toString modulesPath}/../lib/make-disk-image.nix" {
+        inherit lib config pkgs;
+        inherit (config.virtualisation) diskSize;
+        format = "qcow2";
+        partitionTableType = "efi";
+      };
+  };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -3,17 +3,16 @@
     "deploy-o-matic": {
       "inputs": {
         "deploy-rs": "deploy-rs",
-        "nixos-generators": "nixos-generators",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1759050889,
-        "narHash": "sha256-zrU3PgJhRM9BxWjJtXTqwvYnB6niT0iMFjqiY9i99Xg=",
+        "lastModified": 1759251765,
+        "narHash": "sha256-hHRiHgWt6ydR/rLHYYhcnqI2ZHuhqaXO86s3P6XCM0k=",
         "owner": "dexterlb",
         "repo": "deploy-o-matic",
-        "rev": "30b6e36868b0110173fdff063948331d37827b43",
+        "rev": "6c1573ae47de4241412800496b1cf31ce3d52dc8",
         "type": "github"
       },
       "original": {
@@ -79,43 +78,6 @@
         "owner": "nix-community",
         "ref": "master",
         "repo": "home-manager",
-        "type": "github"
-      }
-    },
-    "nixlib": {
-      "locked": {
-        "lastModified": 1736643958,
-        "narHash": "sha256-tmpqTSWVRJVhpvfSN9KXBvKEXplrwKnSZNAoNPf/S/s=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "1418bc28a52126761c02dd3d89b2d8ca0f521181",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixos-generators": {
-      "inputs": {
-        "nixlib": "nixlib",
-        "nixpkgs": [
-          "deploy-o-matic",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1751903740,
-        "narHash": "sha256-PeSkNMvkpEvts+9DjFiop1iT2JuBpyknmBUs0Un0a4I=",
-        "owner": "nix-community",
-        "repo": "nixos-generators",
-        "rev": "032decf9db65efed428afd2fa39d80f7089085eb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixos-generators",
         "type": "github"
       }
     },

--- a/templates/video-player-rpi/hosts.nix
+++ b/templates/video-player-rpi/hosts.nix
@@ -4,7 +4,7 @@ let
   mkHost = hostname: rec {
     inherit hostname;
     system = "aarch64-linux";
-    image = { format = "sd-aarch64"; };
+    image = { format = "sdImage"; };
     moduleArgs = { inherit hostname; };
   };
 in map mkHost hostnames


### PR DESCRIPTION
It turns out that using nixos-generators in our case is a bit stupid because it injects extra modules into the build, and those modules are not visible to deploy-rs.

In particular, the grub settings are not included in the nixos configuration (because nixos-generators includes them later), and when deploy-rs deploys the system, it makes it unbootable.

This commit removes the dependence on nixos-generators by specifying all relevant options (that would otherwise be injected by nixos-generators) locally. It turns out that for non-qemu hosts this change is quite minimal, but it fixes weird deploy-rs failures.
