### PR TITLE
Audio patchbay for use with obs

### DIFF
--- a/common/qpwgraph/data/patchbays/obs-audio.qpwgraph
+++ b/common/qpwgraph/data/patchbays/obs-audio.qpwgraph
@@ -1,13 +1,29 @@
 <!DOCTYPE patchbay>
-<patchbay name="baba" version="0.9.5">
+<patchbay name="main" version="0.9.5">
  <items>
   <item node-type="pipewire" port-type="pipewire-audio">
-   <output node="Blue Snowball Mono" port="Blue Snowball:capture_MONO"/>
-   <input node="Headphones L HD599" port="Headphones L HD599:playback_FR"/>
+   <output node="capture-lecturer Pro" port="Hagibis:capture_AUX1"/>
+   <input node="OBS Studio: Lecturer audio capture" port="OBS Studio: Lecturer audio capture:in_2"/>
   </item>
   <item node-type="pipewire" port-type="pipewire-audio">
-   <output node="Blue Snowball Mono" port="Blue Snowball:capture_MONO"/>
-   <input node="Headphones L HD599" port="Headphones L HD599:playback_FL"/>
+   <output node="OBS Monitor" port="obsMonitor:monitor_FR"/>
+   <input node="out-streamcam Pro" port="Audio Board:playback_AUX1"/>
+  </item>
+  <item node-type="pipewire" port-type="pipewire-audio">
+   <output node="capture-overview Pro" port="Hagibis:capture_AUX0"/>
+   <input node="OBS Studio: Stream mix audio capture" port="OBS Studio: Stream mix audio capture:in_1"/>
+  </item>
+  <item node-type="pipewire" port-type="pipewire-audio">
+   <output node="capture-lecturer Pro" port="Hagibis:capture_AUX0"/>
+   <input node="OBS Studio: Lecturer audio capture" port="OBS Studio: Lecturer audio capture:in_1"/>
+  </item>
+  <item node-type="pipewire" port-type="pipewire-audio">
+   <output node="capture-overview Pro" port="Hagibis:capture_AUX1"/>
+   <input node="OBS Studio: Stream mix audio capture" port="OBS Studio: Stream mix audio capture:in_2"/>
+  </item>
+  <item node-type="pipewire" port-type="pipewire-audio">
+   <output node="OBS Monitor" port="obsMonitor:monitor_FL"/>
+   <input node="out-streamcam Pro" port="Audio Board:playback_AUX0"/>
   </item>
  </items>
 </patchbay>

--- a/common/qpwgraph/data/qpwgraph.conf
+++ b/common/qpwgraph/data/qpwgraph.conf
@@ -6,8 +6,8 @@ Enabled=true
 List=PulseAudio Volume Control
 
 [GraphCanvas]
-CanvasRect="@Variant(\0\0\0\x14\xc0\x9d\x82\xb8Q\xeb\x85\x1f\xc0\x93\xc5\xa3\xd7\n=q@\xa9\x82\xb8Q\xeb\x85\x1e@\xa2G\xa3\xd7\n=p)"
-CanvasZoom=0.40000000000000013
+CanvasRect=@Variant(\0\0\0\x14\xc0\xa1i\x8f\\(\xf5\xc3\xc0\xa8\x4\xfa\xe1G\xae\x14@\xb0\xc9\x8f\\(\xf5\xc3@\xb8\x93\xfa\xe1G\xae\x14)
+CanvasZoom=0.8
 
 [GraphColors]
 0x172973e6=#006b6b
@@ -17,21 +17,24 @@ CanvasZoom=0.40000000000000013
 0xb91441cf=#006b00
 
 [GraphGeometry]
-qpwgraph_main=@ByteArray(\x1\xd9\xd0\xcb\0\x3\0\0\0\0\vB\0\0\x1\xa0\0\0\xe\xf7\0\0\x3\"\0\0\vD\0\0\x1\xb6\0\0\xe\xf5\0\0\x3 \0\0\0\x1\0\0\0\0\a\x80\0\0\vD\0\0\x1\xb6\0\0\xe\xf5\0\0\x3 )
-qpwgraph_patchman=@ByteArray(\x1\xd9\xd0\xcb\0\x3\0\0\0\0\a\xdb\0\0\x1\xb9\0\0\v\xb0\0\0\x4\xae\0\0\a\xdd\0\0\x1\xcf\0\0\v\xae\0\0\x4\xac\0\0\0\x1\0\0\0\0\a\x80\0\0\a\xdd\0\0\x1\xcf\0\0\v\xae\0\0\x4\xac)
+qpwgraph_main=@ByteArray(\x1\xd9\xd0\xcb\0\x3\0\0\0\0\0\0\0\0\0\0\0\0\a{\0\0\x4\x2\0\0\0\0\0\0\0\0\0\0\a{\0\0\x4\x2\0\0\0\x2\0\0\0\0\a\x80\0\0\0\0\0\0\0\0\0\0\a{\0\0\x4\x2)
+qpwgraph_patchman="@ByteArray(\x1\xd9\xd0\xcb\0\x3\0\0\0\0\x2p\0\0\x1=\0\0\x4\xf7\0\0\x2t\0\0\x2p\0\0\x1=\0\0\x4\xf7\0\0\x2t\0\0\0\x2\0\0\0\0\a\x80\0\0\x2p\0\0\x1=\0\0\x4\xf7\0\0\x2t)"
 
 [GraphLayout]
-qpwgraph_main=@ByteArray(\0\0\0\xff\0\0\0\0\xfd\0\0\0\0\0\0\x3\xb2\0\0\0\xea\0\0\0\x4\0\0\0\x4\0\0\0\b\0\0\0\b\xfc\0\0\0\x2\0\0\0\x2\0\0\0\x1\0\0\0\x18\0g\0r\0\x61\0p\0h\0T\0o\0o\0l\0\x62\0\x61\0r\x1\0\0\0\0\xff\xff\xff\xff\0\0\0\0\0\0\0\0\0\0\0\x2\0\0\0\x1\0\0\0\x1e\0p\0\x61\0t\0\x63\0h\0\x62\0\x61\0y\0T\0o\0o\0l\0\x62\0\x61\0r\x1\0\0\0\0\xff\xff\xff\xff\0\0\0\0\0\0\0\0)
+qpwgraph_main=@ByteArray(\0\0\0\xff\0\0\0\0\xfd\0\0\0\0\0\0\a|\0\0\x3\x87\0\0\0\x4\0\0\0\x4\0\0\0\b\0\0\0\b\xfc\0\0\0\x2\0\0\0\x2\0\0\0\x1\0\0\0\x18\0g\0r\0\x61\0p\0h\0T\0o\0o\0l\0\x62\0\x61\0r\x1\0\0\0\0\xff\xff\xff\xff\0\0\0\0\0\0\0\0\0\0\0\x2\0\0\0\x1\0\0\0\x1e\0p\0\x61\0t\0\x63\0h\0\x62\0\x61\0y\0T\0o\0o\0l\0\x62\0\x61\0r\x1\0\0\0\0\xff\xff\xff\xff\0\0\0\0\0\0\0\0)
 
 [GraphNodePos]
 128%3Arosegarden=@Variant(\0\0\0\x1a\xc0\x7f@\0\0\0\0\0\xc0Q\0\0\0\0\0\0)
 129%3AFLUID%20Synth%20%285220%29=@Variant(\0\0\0\x1a\xc0P\0\0\0\0\0\0@`\x80\0\0\0\0\0)
+129%3Alibremidi%20client=@Variant(\0\0\0\x1a@\x8f\0\0\0\0\0\0@T\0\0\0\0\0\0)
 129%3Arosegarden=@Variant(\0\0\0\x1a\xc0\x84@\0\0\0\0\0@n\0\0\0\0\0\0)
 130%3AFLUID%20Synth%20%28306437%29=@Variant(\0\0\0\x1a\xc0m\0\0\0\0\0\0\xc0\x62\x80\0\0\0\0\0)
 130%3AFLUID%20Synth%20%28308324%29=@Variant(\0\0\0\x1a\xc0[\xf1\xc7\x1cq\xc7\x18@\x86\xae\x38\xe3\x8e\x38\xe4)
 130%3AFLUID%20Synth%20%28311946%29=@Variant(\0\0\0\x1a@d\x7f\xff\xff\xff\xff\xfe@w\xe0\0\0\0\0\0)
-14%3AMidi%20Through%3AInput=@Variant(\0\0\0\x1a\xc0r\xc0\0\0\0\0\0\xc0\x63\0\0\0\0\0\0)
-14%3AMidi%20Through%3AOutput=@Variant(\0\0\0\x1a\xc0\x84\0\0\0\0\0\0\xc0|@\0\0\0\0\0)
+14%3AMidi%20Through%3AInput=@Variant(\0\0\0\x1a@\x93\0\0\0\0\0\0@q\xc0\0\0\0\0\0)
+14%3AMidi%20Through%3AOutput=@Variant(\0\0\0\x1a@\x8c\0\0\0\0\0\0@w@\0\0\0\0\0)
+24%3AAudio%20Board%3AInput=@Variant(\0\0\0\x1a@\x8f\xa0\0\0\0\0\0@f\0\0\0\0\0\0)
+24%3AAudio%20Board%3AOutput=@Variant(\0\0\0\x1a@\x87\0\0\0\0\0\0@g\x80\0\0\0\0\0)
 32%3AAudio%20Board%3AInput=@Variant(\0\0\0\x1a@w\0\0\0\0\0\0\x80\0\0\0\0\0\0\0)
 32%3AAudio%20Board%3AOutput=@Variant(\0\0\0\x1a\xc0\x92\xa0\0\0\0\0\0\xc0(\0\0\0\0\0\0)
 32%3AE-MU%200404%20%7C%20USB%3AInput=@Variant(\0\0\0\x1a@\x81\x13\x8e\x38\xe3\x8e\x39\xc0\x45\xe3\x8e\x38\xe3\x8e@)
@@ -51,6 +54,8 @@ Audio%20Board%20Analog%20Stereo%3AOutput=@Variant(\0\0\0\x1a\xc0\x94\x10\0\0\0\0
 Audio%20Board%20Pro%20%5BMonitor%5D=@Variant(\0\0\0\x1a\xc0\x61\x80\0\0\0\0\0\xc0\x87`\0\0\0\0\0)
 Audio%20Board%20Pro%3AInput=@Variant(\0\0\0\x1a@\x85\x80\0\0\0\0\0\xc0\x8d \0\0\0\0\0)
 Audio%20Board%20Pro%3AOutput=@Variant(\0\0\0\x1a\xc0\x8c`\0\0\0\0\0\xc0\x8f \0\0\0\0\0)
+BLE%20MIDI%201%3AInput=@Variant(\0\0\0\x1a@\x90`\0\0\0\0\0@r@\0\0\0\0\0)
+BLE%20MIDI%201%3AOutput=@Variant(\0\0\0\x1a@\x92\x80\0\0\0\0\0@y@\0\0\0\0\0)
 Blender=@Variant(\0\0\0\x1a@x\x80\0\0\0\0\0\xc0U\0\0\0\0\0\0)
 Blue%20Snowball%20Mono%3AOutput=@Variant(\0\0\0\x1a\xc0\x8b \0\0\0\0\0\xc0\x91\x90\0\0\0\0\0)
 Chromium=@Variant(\0\0\0\x1a@q@\0\0\0\0\0\xc0\x8a@\0\0\0\0\0)
@@ -78,6 +83,10 @@ Firefox%3AOutput=@Variant(\0\0\0\x1a\xc0\x93\xd0\0\0\0\0\0\xc0\x84\0\0\0\0\0\0)
 Firefox_1=@Variant(\0\0\0\x1a\xc0\x44\x80\0\0\0\0\x18\xc0\x95\x92\0\0\0\0\x2)
 Firefox_1%3AOutput=@Variant(\0\0\0\x1a\xc0\x8b@\0\0\0\0\0\xc0L\0\0\0\0\0\0)
 H264%20USB%20Camera%20Mono%3AOutput=@Variant(\0\0\0\x1a\xc0\x8e`\0\0\0\0\0\xc0\x8a@\0\0\0\0\0)
+Hagibis%20%28V4L2%29-1%3AOutput=@Variant(\0\0\0\x1a\xc0\x96\xf0\0\0\0\0\0\xc0\xa1\xd8\0\0\0\0\0)
+Hagibis%20%28V4L2%29-2%3AOutput=@Variant(\0\0\0\x1a\xc0\x97\0\0\0\0\0\0@\xa6h\0\0\0\0\0)
+Hagibis%20%28V4L2%29-3%3AOutput=@Variant(\0\0\0\x1a\xc0\x96\xc0\0\0\0\0\0\xc0\xa5\xb0\0\0\0\0\0)
+Hagibis%20%28V4L2%29%3AOutput=@Variant(\0\0\0\x1a\xc0\x96\xd0\0\0\0\0\0@\xa2\xa0\0\0\0\0\0)
 Headphones%20L=@Variant(\0\0\0\x1a\xc0\x8b`\0\0\0\0\0\xc0v\0\0\0\0\0\0)
 Headphones%20L%20HD599=@Variant(\0\0\0\x1a\xc0q\0\0\0\0\0\0@U\0\0\0\0\0\0)
 Headphones%20L%20HD599%3AOutput=@Variant(\0\0\0\x1a\xc0x\0\0\0\0\0\0@x@\0\0\0\0\0)
@@ -94,8 +103,8 @@ Living%20room-1=@Variant(\0\0\0\x1a\xc0z\xc0\0\0\0\0\0\xc0\x84@\0\0\0\0\0)
 Living%20room-1_1=@Variant(\0\0\0\x1a\xc0\x80`\0\0\0\0\0\xc0\x92`\0\0\0\0\0)
 Living%20room%3AOutput=@Variant(\0\0\0\x1a@u\xc0\0\0\0\0\0\xc0\x8c`\0\0\0\0\0)
 Living%20room_1=@Variant(\0\0\0\x1a\xc0\x84`\0\0\0\0\0\xc0\x99@\0\0\0\0\0)
-Midi-Bridge%3AInput=@Variant(\0\0\0\x1a@\x83`\0\0\0\0\0@Z\0\0\0\0\0\0)
-Midi-Bridge%3AOutput=@Variant(\0\0\0\x1a\xc0\x87 \0\0\0\0\0\xc0U\0\0\0\0\0\0)
+Midi-Bridge%3AInput=@Variant(\0\0\0\x1a@\x92@\0\0\0\0\0\xc0_\0\0\0\0\0\0)
+Midi-Bridge%3AOutput=@Variant(\0\0\0\x1a@\x8c \0\0\0\0\0\xc0`\0\0\0\0\0\0)
 Music%20Player%20Daemon=@Variant(\0\0\0\x1a\xc0\x8d\xa0\0\0\0\0\0\xc0\x96\0\0\0\0\0\0)
 Music%20Player%20Daemon\mpd.kitchen%3AOutput=@Variant(\0\0\0\x1a\xc0\x9b\x10\0\0\0\0\0\xc0s\0\0\0\0\0\0)
 Navi%2010%20HDMI%20Audio%20Digital%20Stereo%20%28HDMI%203%29%20%5BMonitor%5D=@Variant(\0\0\0\x1a\xc0\x66\xc0\0\0\0\0\0\xc0\x62\xe0\0\0\0\0\0)
@@ -118,6 +127,11 @@ Navi%2010%20HDMI%20Audio%20Pro%209%20%5BMonitor%5D=@Variant(\0\0\0\x1a\xc0q@\0\0
 Navi%2010%20HDMI%20Audio%20Pro%209%3AInput=@Variant(\0\0\0\x1a@F\0\0\0\0\0\0\xc0\x92\xa0\0\0\0\0\0)
 Navi%2010%20HDMI%20Audio%20Pro%20%5BMonitor%5D=@Variant(\0\0\0\x1a\xc0r@\0\0\0\0\0\xc0\x92\xc0\0\0\0\0\0)
 Navi%2010%20HDMI%20Audio%20Pro%3AInput=@Variant(\0\0\0\x1a@P\0\0\0\0\0\0\xc0w\0\0\0\0\0\0)
+OBS%20Monitor=@Variant(\0\0\0\x1a@j\x80\0\0\0\0\0\xc0\x30\0\0\0\0\0\0)
+OBS%20Studio%3A%20Lecturer%20audio%20capture=@Variant(\0\0\0\x1a@d\x80\0\0\0\0\0@k\0\0\0\0\0\0)
+OBS%20Studio%3A%20Stream%20mix%20audio%20capture=@Variant(\0\0\0\x1a@g\0\0\0\0\0\0\xc0o\x80\0\0\0\0\0)
+OBS\OBS-Monitor-1%3AOutput=@Variant(\0\0\0\x1a\xc0\x62\0\0\0\0\0\0@H\0\0\0\0\0\0)
+OBS\OBS-Monitor%3AOutput=@Variant(\0\0\0\x1a\xc0\x61\x80\0\0\0\0\0\xc0R\0\0\0\0\0\0)
 PCM2704%2016-bit%20stereo%20audio%20DAC%20Analog%20Stereo%20%5BMonitor%5D=@Variant(\0\0\0\x1a@e\0\0\0\0\0\0@k\0\0\0\0\0\0)
 PCM2704%2016-bit%20stereo%20audio%20DAC%20Analog%20Stereo%3AInput=@Variant(\0\0\0\x1a\xc0\x8d\xa0\0\0\0\0\0\xc0\x88@\0\0\0\0\0)
 PCM2900C%20Audio%20CODEC%20Analog%20Stereo%20%5BMonitor%5D=@Variant(\0\0\0\x1a@\x7f\0\0\0\0\0\0\xc0r\x80\0\0\0\0\0)
@@ -206,6 +220,8 @@ UMC404HD%20192k%20Pro%3AOutput=@Variant(\0\0\0\x1a\xc0\x88\xe0\0\0\0\0\0@\x89\0\
 %5BvokoscreenNG%5D%20Monitor%20of%20PCM2704%2016-bit%20stereo%20audio%20DAC%20Analog%20Stereo=@Variant(\0\0\0\x1a@p\x80\0\0\0\0\0\xc0o\0\0\0\0\0\0)
 %5BvokoscreenNG%5D%20Monitor%20of%20Starship\Matisse%20HD%20Audio%20Controller%20Analog%20Stereo=@Variant(\0\0\0\x1a@\x80\x80\0\0\0\0\0\xc0q\0\0\0\0\0\0)
 ardour=@Variant(\0\0\0\x1a\xc0}\0\0\0\0\0\0\xc0\x98\xc0\0\0\0\0\0)
+capture-lecturer%20Pro%3AOutput=@Variant(\0\0\0\x1a\xc0`\x80\0\0\0\0\0@k\x80\0\0\0\0\0)
+capture-overview%20Pro%3AOutput=@Variant(\0\0\0\x1a\xc0\x64\0\0\0\0\0\0\xc0r@\0\0\0\0\0)
 fluidsynth=@Variant(\0\0\0\x1a\xc0\x94\x90\0\0\0\0\0\xc0q\x80\0\0\0\0\0)
 guitarix%3AOutput=@Variant(\0\0\0\x1a\xc0\x9e\0\0\0\0\0\0@\xa3(\0\0\0\0\0)
 gx_head_amp=@Variant(\0\0\0\x1a\xc0\x8f@\0\0\0\0\0\xc0m\0\0\0\0\0\0)
@@ -217,6 +233,9 @@ mpv=@Variant(\0\0\0\x1a@~\0\0\0\0\0\0\xc0\x62\0\0\0\0\0\0)
 nheko=@Variant(\0\0\0\x1a@Y\0\0\0\0\0\0\xc0\x91\x30\0\0\0\0\0)
 nheko%3AOutput=@Variant(\0\0\0\x1a\xc0\x90\xb0\0\0\0\0\0@p@\0\0\0\0\0)
 org.inkscape.Inkscape\kicad=@Variant(\0\0\0\x1a@v\0\0\0\0\0\0\xc0\x91`\0\0\0\0\0)
+out-streamcam%20Pro%20%5BMonitor%5D=@Variant(\0\0\0\x1a\xc0Q\0\0\0\0\0\0@x\x80\0\0\0\0\0)
+out-streamcam%20Pro%3AInput=@Variant(\0\0\0\x1a@}@\0\0\0\0\0\xc0\x38\0\0\0\0\0\0)
+out-streamcam%20Pro%3AOutput=@Variant(\0\0\0\x1a\xc0\x91\xe0\0\0\0\0\0@\xa2X\0\0\0\0\0)
 rosegarden=@Variant(\0\0\0\x1a\xc0}\0\0\0\0\0\0\xc0\x8d\xa0\0\0\0\0\0)
 spotify=@Variant(\0\0\0\x1a\xc0n\x80\0\0\0\0\0\xc0\x93\x30\0\0\0\0\0)
 spotify%3AOutput=@Variant(\0\0\0\x1a\xc0\x82\xa0\0\0\0\0\0@~\0\0\0\0\0\0)
@@ -245,7 +264,7 @@ List=@Invalid()
 Activated=true
 AutoDisconnect=false
 AutoPin=true
-Dir=/tmp
+Dir=/home/human/.local/share/patchbays
 Exclusive=false
 Path=/home/human/.local/share/patchbays/main.qpwgraph
 QueryQuit=false


### PR DESCRIPTION
Configure qpwgraph to automatically wire the audio inputs and outputs between obs and the audio cards (that have been set up with the dev mapper).