### PR TITLE
video player machine

### DIFF
--- a/common/caged-mpv.nix
+++ b/common/caged-mpv.nix
@@ -1,0 +1,31 @@
+{ pkgs, videoPlayerTarget, ... }:
+let
+  player = pkgs.writeShellApplication {
+    name = "video-player";
+    runtimeInputs = [ pkgs.cage pkgs.mpv pkgs.cowsay ];
+    text = ''
+      function pre {
+        cowsay 'entertainment will commence shortly'
+      }
+
+      pre
+      while sleep 3; do
+        cage -- mpv \
+          --loop-file=inf \
+          --osc=no \
+          "${videoPlayerTarget}" \
+          || continue
+        pre
+      done
+    '';
+  };
+in {
+  home-manager.users.human = {
+    home.file.".zprofile".text = ''
+      # Auto-start player on first VT if not already under Wayland
+      if [ -z "''${WAYLAND_DISPLAY}" ] && [ "''${XDG_VTNR: -0}" -eq 1 ]; then
+        "${player}/bin/video-player" 2>&1 | ${pkgs.moreutils}/bin/ts > /tmp/player.log
+      fi
+    '';
+  };
+}

--- a/common/video-player.nix
+++ b/common/video-player.nix
@@ -1,0 +1,3 @@
+{ inputs, lib, pkgs, ... }: {
+  imports = [ ./base-config.nix ./audio-config.nix ./caged-mpv.nix ];
+}

--- a/run-qemu.sh
+++ b/run-qemu.sh
@@ -49,7 +49,11 @@ opts=(
   -netdev user,id=n0,hostfwd=tcp::2222-:22
 )
 
-if [[ ! -v QEMU_NO_VGA ]]; then
+if [[ -v QEMU_NO_VGA ]]; then
+  opts+=(
+    -vnc :4
+  )
+else
   opts+=(
     -display gtk -device virtio-vga
   )

--- a/templates/video-player-qemu/default.nix
+++ b/templates/video-player-qemu/default.nix
@@ -1,6 +1,6 @@
 { inputs, lib, config, pkgs, ... }: {
   imports = [
-    ../../common/platforms/aarch64-rpi-bootdisk.nix
+    ../../common/platforms/x86_64-virtio-qemu-img.nix
     ../../common/networking-dhcp.nix
     ../../common/video-player.nix
   ];

--- a/templates/video-player-qemu/hosts.nix
+++ b/templates/video-player-qemu/hosts.nix
@@ -1,0 +1,9 @@
+{ ... }: [rec {
+  hostname = "player-qemu";
+  system = "x86_64-linux";
+  image = { format = "qcow-efi"; };
+  moduleArgs = {
+    inherit hostname;
+    videoPlayerTarget = "https://rnd.qtrp.org/test_videos/cows.mp4";
+  };
+}]

--- a/templates/video-player-rpi/hosts.nix
+++ b/templates/video-player-rpi/hosts.nix
@@ -5,6 +5,9 @@ let
     inherit hostname;
     system = "aarch64-linux";
     image = { format = "sdImage"; };
-    moduleArgs = { inherit hostname; };
+    moduleArgs = {
+      inherit hostname;
+      videoPlayerTarget = "https://rnd.qtrp.org/test_videos/cows.mp4";
+    };
   };
 in map mkHost hostnames


### PR DESCRIPTION
- add a module for running `cage` and `mpv` to play a fullscreen video
- add `video-player-qemu` (with the `player-qemu` machine)
- update `video-player-rpi` (with the `player-0[123]` machines)
    - this *should* be able to run on a raspberry pi 4 by just burning the result of `nix build '.#player-01'` to an SD card
    - it might require fine-tuning, like adding a mmal decoding argument to mpv or enabling a mmal-supporting linux kernel